### PR TITLE
Change package links in the project README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitHub License](https://img.shields.io/github/license/muze-nl/jaqt)](https://github.com/muze-nl/jaqt/blob/main/LICENSE)
 [![GitHub package.json version](https://img.shields.io/github/package-json/v/muze-nl/jaqt)]()
-[![NPM Version](https://img.shields.io/npm/v/jaqt)](https://www.npmjs.com/package/jaqt)
-[![npm bundle size](https://img.shields.io/bundlephobia/min/jaqt)](https://www.npmjs.com/package/jaqt)
+[![NPM Version](https://img.shields.io/npm/v/jaqt)](https://www.npmjs.com/package/@muze-nl/jaqt)
+[![npm bundle size](https://img.shields.io/bundlephobia/min/jaqt)](https://bundlephobia.com/package/@muze-nl/jaqt)
 
 # jaqt: javascript queries and transformations
 


### PR DESCRIPTION
The package was renamed on NPM, but the link in the project README still pointed to the old link.

This MR fixes that.

I've also changed the link for the BundlePhobia badge to point to https://bundlephobia.com/package/@muze-nl/jaqt (in case people want to click through to more details).