### PR TITLE
Change jaqt import example in manual to use an import map.

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -88,8 +88,15 @@ npm install jaqt
 Or use it directly from a CDN like jsdeliver.net:
 
 ```html
+<script type="importmap">
+{
+    "imports": {
+        "@muze-nl/jaqt": "https://cdn.jsdelivr.net/npm/@muze-nl/jaqt/src/jaqt.mjs"
+    }
+}
+</script>
 <script type="module">
-    import * as jaqt from 'https://cdn.jsdelivr.net/npm/@muze-nl/jaqt/src/jaqt.mjs'
+    import * as jaqt from '@muze-nl/jaqt'
 </script>
 ```
 


### PR DESCRIPTION
This MR changes the import example in the manual for using jaqt in the browser to use an `importmap` instead of a full URL in the `import` statement.

@poef Yay / Nay?